### PR TITLE
feat(facade): add faded and unfaded events

### DIFF
--- a/Documentation/API/CollisionFaderConfigurator.md
+++ b/Documentation/API/CollisionFaderConfigurator.md
@@ -13,6 +13,8 @@ Sets up the CollisionFader prefab based on the provided user settings.
   * [FadeOverlay]
   * [SourceFollower]
 * [Methods]
+  * [NotifyFaded()]
+  * [NotifyUnfaded()]
   * [OnEnable()]
   * [SetupCollisionRule()]
   * [SetupFadeOverlay()]
@@ -79,6 +81,26 @@ public ObjectFollower SourceFollower { get; protected set; }
 
 ### Methods
 
+#### NotifyFaded()
+
+Emits the Facade.Faded event.
+
+##### Declaration
+
+```
+public virtual void NotifyFaded()
+```
+
+#### NotifyUnfaded()
+
+Emits the Facade.Unfaded event.
+
+##### Declaration
+
+```
+public virtual void NotifyUnfaded()
+```
+
 #### OnEnable()
 
 ##### Declaration
@@ -131,6 +153,8 @@ public virtual void SetupFollower()
 [FadeOverlay]: #FadeOverlay
 [SourceFollower]: #SourceFollower
 [Methods]: #Methods
+[NotifyFaded()]: #NotifyFaded
+[NotifyUnfaded()]: #NotifyUnfaded
 [OnEnable()]: #OnEnable
 [SetupCollisionRule()]: #SetupCollisionRule
 [SetupFadeOverlay()]: #SetupFadeOverlay

--- a/Documentation/API/CollisionFaderFacade.md
+++ b/Documentation/API/CollisionFaderFacade.md
@@ -7,10 +7,15 @@ The public interface for the CollisionFader prefab.
 * [Inheritance]
 * [Namespace]
 * [Syntax]
+* [Fields]
+  * [Faded]
+  * [Unfaded]
 * [Properties]
   * [CameraValidity]
+  * [ColliderContainer]
   * [CollisionValidity]
   * [Configuration]
+  * [OverlayContainer]
   * [Source]
 * [Methods]
   * [ClearCameraValidity()]
@@ -37,6 +42,26 @@ The public interface for the CollisionFader prefab.
 public class CollisionFaderFacade : MonoBehaviour
 ```
 
+### Fields
+
+#### Faded
+
+##### Declaration
+
+```
+public UnityEvent Faded
+```
+
+#### Unfaded
+
+Emitted when the screen has unfaded completely.
+
+##### Declaration
+
+```
+public UnityEvent Unfaded
+```
+
 ### Properties
 
 #### CameraValidity
@@ -47,6 +72,16 @@ The rules to determine which scene cameras to apply the overlay to.
 
 ```
 public RuleContainer CameraValidity { get; set; }
+```
+
+#### ColliderContainer
+
+The container of the collider and collision logic.
+
+##### Declaration
+
+```
+public ObjectReference ColliderContainer { get; protected set; }
 ```
 
 #### CollisionValidity
@@ -67,6 +102,16 @@ The linked Internal Setup.
 
 ```
 public CollisionFaderConfigurator Configuration { get; protected set; }
+```
+
+#### OverlayContainer
+
+The container of the camera overlay and fading logic.
+
+##### Declaration
+
+```
+public ObjectReference OverlayContainer { get; protected set; }
 ```
 
 #### Source
@@ -152,10 +197,15 @@ protected virtual void OnAfterSourceChange()
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
 [Syntax]: #Syntax
+[Fields]: #Fields
+[Faded]: #Faded
+[Unfaded]: #Unfaded
 [Properties]: #Properties
 [CameraValidity]: #CameraValidity
+[ColliderContainer]: #ColliderContainer
 [CollisionValidity]: #CollisionValidity
 [Configuration]: #Configuration
+[OverlayContainer]: #OverlayContainer
 [Source]: #Source
 [Methods]: #Methods
 [ClearCameraValidity()]: #ClearCameraValidity

--- a/Runtime/Prefabs/Visuals.CollisionFader.prefab
+++ b/Runtime/Prefabs/Visuals.CollisionFader.prefab
@@ -53,28 +53,40 @@ MonoBehaviour:
   Added:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Visual.CameraColorOverlay+UnityEvent, Zinnia.Runtime, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   AddTransitioned:
     m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: Zinnia.Visual.CameraColorOverlay+UnityEvent, Zinnia.Runtime, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
+      m_Calls:
+      - m_Target: {fileID: 172949327018806479}
+        m_MethodName: NotifyFaded
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   Removed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Visual.CameraColorOverlay+UnityEvent, Zinnia.Runtime, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   RemoveTransitioned:
     m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: Zinnia.Visual.CameraColorOverlay+UnityEvent, Zinnia.Runtime, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
+      m_Calls:
+      - m_Target: {fileID: 172949327018806479}
+        m_MethodName: NotifyUnfaded
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   Changed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Visual.CameraColorOverlay+UnityEvent, Zinnia.Runtime, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!1 &3601242204351176734
 GameObject:
   m_ObjectHideFlags: 0
@@ -85,9 +97,9 @@ GameObject:
   m_Component:
   - component: {fileID: 3601242204351176735}
   - component: {fileID: 3601242204351176732}
+  - component: {fileID: 3601242204351176723}
   - component: {fileID: 3601242204351176722}
   - component: {fileID: 3601242204351176733}
-  - component: {fileID: 3601242204351176723}
   m_Layer: 0
   m_Name: ColliderContainer
   m_TagString: Untagged
@@ -122,6 +134,22 @@ SphereCollider:
   serializedVersion: 2
   m_Radius: 0.325
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &3601242204351176723
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3601242204351176734}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
 --- !u!114 &3601242204351176722
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -153,13 +181,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-    m_TypeName: Zinnia.Tracking.Collision.CollisionNotifier+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   CollisionChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Tracking.Collision.CollisionNotifier+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   CollisionStopped:
     m_PersistentCalls:
       m_Calls:
@@ -174,9 +198,12 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-    m_TypeName: Zinnia.Tracking.Collision.CollisionNotifier+UnityEvent, Zinnia.Runtime,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   stopCollisionsOnDisable: 1
+  colliderValidity:
+    field: {fileID: 0}
+  containingTransformValidity:
+    field: {fileID: 0}
+  stayDelayInterval: 0
 --- !u!114 &3601242204351176733
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -207,27 +234,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-    m_TypeName: Zinnia.Tracking.Collision.Event.Proxy.CollisionNotifierEventProxyEmitter+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   receiveValidity:
     field: {fileID: 0}
   ruleSource: 1
---- !u!54 &3601242204351176723
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3601242204351176734}
-  serializedVersion: 2
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_UseGravity: 0
-  m_IsKinematic: 1
-  m_Interpolate: 0
-  m_Constraints: 0
-  m_CollisionDetection: 0
 --- !u!1 &3601242204718771730
 GameObject:
   m_ObjectHideFlags: 0
@@ -277,6 +286,20 @@ MonoBehaviour:
     field: {fileID: 0}
   collisionValidity:
     field: {fileID: 0}
+  Faded:
+    m_PersistentCalls:
+      m_Calls: []
+  Unfaded:
+    m_PersistentCalls:
+      m_Calls: []
+  colliderContainer:
+    linkedObject: {fileID: 3601242204351176734}
+    linkText: Show Collider Container
+    isActive: 1
+  overlayContainer:
+    linkedObject: {fileID: 3601242203177762290}
+    linkText: Show Overlay Container
+    isActive: 1
   configuration: {fileID: 172949327018806479}
 --- !u!1 &4801409090143682716
 GameObject:
@@ -335,6 +358,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 7051741665305264477}
     m_Modifications:
+    - target: {fileID: 1068226196861958, guid: 9aa99d00578590e45a52faa205a1014a, type: 3}
+      propertyPath: m_Name
+      value: Mutators.ObjectFollower
+      objectReference: {fileID: 0}
     - target: {fileID: 4952949373149400, guid: 9aa99d00578590e45a52faa205a1014a, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -378,10 +405,6 @@ PrefabInstance:
     - target: {fileID: 4952949373149400, guid: 9aa99d00578590e45a52faa205a1014a, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1068226196861958, guid: 9aa99d00578590e45a52faa205a1014a, type: 3}
-      propertyPath: m_Name
-      value: Mutators.ObjectFollower
       objectReference: {fileID: 0}
     - target: {fileID: 1392910959889882537, guid: 9aa99d00578590e45a52faa205a1014a,
         type: 3}

--- a/Runtime/SharedResources/Scripts/CollisionFaderConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/CollisionFaderConfigurator.cs
@@ -122,6 +122,22 @@
             FadeOverlay.CameraValidity = FadeOverlay.CameraValidity;
         }
 
+        /// <summary>
+        /// Emits the <see cref="Facade.Faded"/> event.
+        /// </summary>
+        public virtual void NotifyFaded()
+        {
+            Facade.Faded?.Invoke();
+        }
+
+        /// <summary>
+        /// Emits the <see cref="Facade.Unfaded"/> event.
+        /// </summary>
+        public virtual void NotifyUnfaded()
+        {
+            Facade.Unfaded?.Invoke();
+        }
+
         protected virtual void OnEnable()
         {
             SetupFollower();

--- a/Runtime/SharedResources/Scripts/CollisionFaderFacade.cs
+++ b/Runtime/SharedResources/Scripts/CollisionFaderFacade.cs
@@ -1,7 +1,9 @@
 ﻿namespace Tilia.Visuals.CollisionFader
 {
     using UnityEngine;
+    using UnityEngine.Events;
     using Zinnia.Data.Attribute;
+    using Zinnia.Data.Type;
     using Zinnia.Extension;
     using Zinnia.Rule;
 
@@ -77,8 +79,55 @@
         }
         #endregion
 
+        #region Fading Events
+        [Header("Fading Events")]
+        /// <summary>
+        /// Emitted when the screen has faded completely.
+        /// </summary>
+        public UnityEvent Faded = new UnityEvent();
+        /// <summary>
+        /// Emitted when the screen has unfaded completely.
+        /// </summary>
+        public UnityEvent Unfaded = new UnityEvent();
+        #endregion
+
         #region Reference Settings
         [Header("Reference Settings")]
+
+        [Tooltip("The container of the collider and collision logic.")]
+        [SerializeField]
+        private ObjectReference colliderContainer;
+        /// <summary>
+        /// The container of the collider and collision logic.
+        /// </summary>
+        public ObjectReference ColliderContainer
+        {
+            get
+            {
+                return colliderContainer;
+            }
+            protected set
+            {
+                colliderContainer = value;
+            }
+        }
+        [Tooltip("The container of the camera overlay and fading logic.")]
+        [SerializeField]
+        private ObjectReference overlayContainer;
+        /// <summary>
+        /// The container of the camera overlay and fading logic.
+        /// </summary>
+        public ObjectReference OverlayContainer
+        {
+            get
+            {
+                return overlayContainer;
+            }
+            protected set
+            {
+                overlayContainer = value;
+            }
+        }
         [Tooltip("The linked Internal Setup.")]
         [SerializeField]
         [Restricted]


### PR DESCRIPTION
The Faded and Unfaded events are now bubbled to the facade to make
it easier to access these moments. A couple of extra ObjectReference
settings have been added too so it is easier to get to the relevant
internal elements.