### PR TITLE
fix(Rule): ensure collision rule blocks collision forwarding

### DIFF
--- a/Documentation/API/CollisionFaderConfigurator.md
+++ b/Documentation/API/CollisionFaderConfigurator.md
@@ -11,6 +11,7 @@ Sets up the CollisionFader prefab based on the provided user settings.
   * [CollisionProxy]
   * [Facade]
   * [FadeOverlay]
+  * [SourceCollisionTracker]
   * [SourceFollower]
 * [Methods]
   * [NotifyFaded()]
@@ -67,6 +68,16 @@ The linked CameraColorOverlay to use to fade the camera.
 
 ```
 public CameraColorOverlay FadeOverlay { get; protected set; }
+```
+
+#### SourceCollisionTracker
+
+The linked CollisionTracker to track collisions with.
+
+##### Declaration
+
+```
+public CollisionTracker SourceCollisionTracker { get; protected set; }
 ```
 
 #### SourceFollower
@@ -151,6 +162,7 @@ public virtual void SetupFollower()
 [CollisionProxy]: #CollisionProxy
 [Facade]: #Facade
 [FadeOverlay]: #FadeOverlay
+[SourceCollisionTracker]: #SourceCollisionTracker
 [SourceFollower]: #SourceFollower
 [Methods]: #Methods
 [NotifyFaded()]: #NotifyFaded

--- a/Runtime/Prefabs/Visuals.CollisionFader.prefab
+++ b/Runtime/Prefabs/Visuals.CollisionFader.prefab
@@ -349,6 +349,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   facade: {fileID: 6159375174619301438}
   sourceFollower: {fileID: 3486422414244705064}
+  sourceCollisionTracker: {fileID: 3601242204351176722}
   collisionProxy: {fileID: 3601242204351176733}
   fadeOverlay: {fileID: 3601242203177762288}
 --- !u!1001 &3601242203254135430

--- a/Runtime/SharedResources/Scripts/CollisionFaderConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/CollisionFaderConfigurator.cs
@@ -3,6 +3,7 @@
     using UnityEngine;
     using Zinnia.Data.Attribute;
     using Zinnia.Extension;
+    using Zinnia.Tracking.Collision;
     using Zinnia.Tracking.Collision.Event.Proxy;
     using Zinnia.Tracking.Follow;
     using Zinnia.Visual;
@@ -52,6 +53,24 @@
             protected set
             {
                 sourceFollower = value;
+            }
+        }
+        [Tooltip("The linked CollisionTracker to track collisions with.")]
+        [SerializeField]
+        [Restricted]
+        private CollisionTracker sourceCollisionTracker;
+        /// <summary>
+        /// The linked <see cref="CollisionTracker"/> to track collisions with.
+        /// </summary>
+        public CollisionTracker SourceCollisionTracker
+        {
+            get
+            {
+                return sourceCollisionTracker;
+            }
+            protected set
+            {
+                sourceCollisionTracker = value;
             }
         }
         [Tooltip("The linked CollisionNotifierEventProxyEmitter to set the valid collisions rule on.")]
@@ -111,7 +130,15 @@
         /// </summary>
         public virtual void SetupCollisionRule()
         {
-            CollisionProxy.ReceiveValidity = Facade.CollisionValidity;
+            if (SourceCollisionTracker != null)
+            {
+                SourceCollisionTracker.ForwardingSourceValidity = Facade.CollisionValidity;
+            }
+
+            if (CollisionProxy != null)
+            {
+                CollisionProxy.ReceiveValidity = Facade.CollisionValidity;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Because the internal Collision Tracker extends a Collision Notifier this means that any collision with another object that contains a Collision Notifier/Tracker type will forward the collisions to the Collision Fader's Collision Tracker and therefore the Collision Validity rule will be ignored.

This fix sets the internal Collision Tracker Forward Source Validity to match that of the Facade Collision Validity to prevent this issue occuring.